### PR TITLE
Add view and edit pages for saved tasks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,46 @@ impl Task {
         })
         .await
     }
+
+    pub async fn find(db: &Db, id: i64) -> Option<Task> {
+        db.run(move |conn| {
+            conn.query_row(
+                "SELECT id, name, status, date FROM tasks WHERE id = ?",
+                [id],
+                |row| {
+                    Ok(Task {
+                        id: Some(row.get(0)?),
+                        name: row.get(1)?,
+                        status: row.get(2)?,
+                        date: row.get(3)?,
+                    })
+                },
+            )
+            .ok()
+        })
+        .await
+    }
+
+    pub async fn update(db: &Db, id: i64, task: Task) -> bool {
+        db.run(move |conn| {
+            conn.execute(
+                "UPDATE tasks SET name = ?, status = ?, date = ? WHERE id = ?",
+                rusqlite::params![task.name, task.status, task.date, id],
+            )
+            .expect("failed to update")
+                > 0
+        })
+        .await
+    }
+
+    pub async fn delete(db: &Db, id: i64) -> bool {
+        db.run(move |conn| {
+            conn.execute("DELETE FROM tasks WHERE id = ?", [id])
+                .expect("failed to delete")
+                > 0
+        })
+        .await
+    }
 }
 
 #[get("/")]
@@ -86,6 +126,32 @@ async fn create_task_json(db: Db, task: Json<Task>) -> Json<Task> {
     Json(task_obj)
 }
 
+#[get("/task/<id>")]
+async fn view_task(db: Db, id: i64) -> Option<Template> {
+    Task::find(&db, id)
+        .await
+        .map(|task| Template::render("view", context! { task: task }))
+}
+
+#[get("/task/<id>/edit")]
+async fn edit_task(db: Db, id: i64) -> Option<Template> {
+    Task::find(&db, id)
+        .await
+        .map(|task| Template::render("edit", context! { task: task }))
+}
+
+#[post("/task/<id>", data = "<task>")]
+async fn update_task(db: Db, id: i64, task: rocket::form::Form<Task>) -> rocket::response::Redirect {
+    Task::update(&db, id, task.into_inner()).await;
+    rocket::response::Redirect::to("/")
+}
+
+#[post("/task/<id>/delete")]
+async fn delete_task(db: Db, id: i64) -> rocket::response::Redirect {
+    Task::delete(&db, id).await;
+    rocket::response::Redirect::to("/")
+}
+
 #[launch]
 pub fn rocket() -> _ {
     rocket::build()
@@ -110,7 +176,16 @@ pub fn rocket() -> _ {
         }))
         .mount(
             "/",
-            routes![index, get_tasks, create_task_form, create_task_json],
+            routes![
+                index,
+                get_tasks,
+                create_task_form,
+                create_task_json,
+                view_task,
+                edit_task,
+                update_task,
+                delete_task
+            ],
         )
 }
 
@@ -187,5 +262,103 @@ mod tests {
         assert!(tasks
             .iter()
             .any(|t| t.name == task_name && t.status == "done"));
+    }
+
+    #[test]
+    fn test_view_task() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+
+        // 1. Create a task
+        let task_name = format!("View Test Task {}", uuid::Uuid::new_v4());
+        let response = client
+            .post("/tasks")
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{"name": "{}", "status": "new", "date": "2023-10-27"}}"#,
+                task_name
+            ))
+            .dispatch();
+        let task: Task = response.into_json().expect("valid JSON task");
+        let id = task.id.unwrap();
+
+        // 2. View the task
+        let response = client.get(format!("/task/{}", id)).dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        assert!(body.contains(&task_name));
+        assert!(body.contains("Task Details"));
+    }
+
+    #[test]
+    fn test_edit_and_update_task() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+
+        // 1. Create a task
+        let task_name = format!("Edit Test Task {}", uuid::Uuid::new_v4());
+        let response = client
+            .post("/tasks")
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{"name": "{}", "status": "new", "date": "2023-10-27"}}"#,
+                task_name
+            ))
+            .dispatch();
+        let task: Task = response.into_json().expect("valid JSON task");
+        let id = task.id.unwrap();
+
+        // 2. Get edit page
+        let response = client.get(format!("/task/{}/edit", id)).dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        assert!(response.into_string().unwrap().contains("Edit Task"));
+
+        // 3. Update the task
+        let updated_name = format!("Updated Task {}", uuid::Uuid::new_v4());
+        let body = format!("name={}&status=done&date=2024-01-01", updated_name);
+        let response = client
+            .post(format!("/task/{}", id))
+            .header(ContentType::Form)
+            .body(body)
+            .dispatch();
+        assert_eq!(response.status(), Status::SeeOther);
+
+        // 4. Verify update
+        let response = client.get(format!("/task/{}", id)).dispatch();
+        let body = response.into_string().unwrap();
+        assert!(body.contains(&updated_name));
+        assert!(body.contains("Done"));
+        assert!(body.contains("2024-01-01"));
+    }
+
+    #[test]
+    fn test_delete_task() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+
+        // 1. Create a task
+        let task_name = format!("Delete Test Task {}", uuid::Uuid::new_v4());
+        let response = client
+            .post("/tasks")
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{"name": "{}", "status": "new", "date": "2023-10-27"}}"#,
+                task_name
+            ))
+            .dispatch();
+        let task: Task = response.into_json().expect("valid JSON task");
+        let id = task.id.unwrap();
+
+        // 2. Delete the task
+        let response = client.post(format!("/task/{}/delete", id)).dispatch();
+        assert_eq!(response.status(), Status::SeeOther);
+
+        // 3. Verify it's gone
+        let response = client.get(format!("/task/{}", id)).dispatch();
+        assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[test]
+    fn test_task_not_found() {
+        let client = Client::tracked(rocket()).expect("valid rocket instance");
+        let response = client.get("/task/999999").dispatch();
+        assert_eq!(response.status(), Status::NotFound);
     }
 }

--- a/templates/edit.html.tera
+++ b/templates/edit.html.tera
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Task - Task Tracker</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="container mx-auto px-4 py-8 max-w-2xl">
+        <header class="mb-10 text-center">
+            <h1 class="text-4xl font-extrabold text-gray-900 mb-2">Edit Task</h1>
+            <p class="text-lg text-gray-600">Update your task information</p>
+        </header>
+
+        <div class="bg-white rounded-lg shadow-md p-6">
+            <form action="/task/{{ task.id }}" method="post" class="space-y-6">
+                <div>
+                    <label for="name" class="block mb-2 text-sm font-medium text-gray-900">Task Name</label>
+                    <input type="text" id="name" name="name" value="{{ task.name }}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label for="status" class="block mb-2 text-sm font-medium text-gray-900">Status</label>
+                        <select id="status" name="status" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                            <option value="new" {% if task.status == "new" %}selected{% endif %}>New</option>
+                            <option value="done" {% if task.status == "done" %}selected{% endif %}>Done</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="date" class="block mb-2 text-sm font-medium text-gray-900">Date</label>
+                        <div class="relative">
+                            <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                                <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z"/>
+                                </svg>
+                            </div>
+                            <input id="date" name="date" type="date" value="{{ task.date }}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5" required>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-end space-x-4 pt-4 border-t border-gray-100">
+                    <a href="/" class="py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200">Cancel</a>
+                    <button type="submit" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center">Save Changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
+</body>
+</html>

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -59,7 +59,8 @@
                         <tr>
                             <th scope="col" class="px-6 py-3">Task Name</th>
                             <th scope="col" class="px-6 py-3 text-center">Status</th>
-                            <th scope="col" class="px-6 py-3 text-right">Date</th>
+                            <th scope="col" class="px-6 py-3 text-center">Date</th>
+                            <th scope="col" class="px-6 py-3 text-right">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -75,14 +76,21 @@
                                 <span class="bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded-full">New</span>
                                 {% endif %}
                             </td>
-                            <td class="px-6 py-4 text-right">
+                            <td class="px-6 py-4 text-center">
                                 {{ task.date }}
+                            </td>
+                            <td class="px-6 py-4 text-right space-x-2">
+                                <a href="/task/{{ task.id }}" class="font-medium text-blue-600 hover:underline">View</a>
+                                <a href="/task/{{ task.id }}/edit" class="font-medium text-green-600 hover:underline">Edit</a>
+                                <form action="/task/{{ task.id }}/delete" method="post" class="inline">
+                                    <button type="submit" class="font-medium text-red-600 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
+                                </form>
                             </td>
                         </tr>
                         {% endfor %}
                         {% if tasks | length == 0 %}
                         <tr>
-                            <td colspan="3" class="px-6 py-10 text-center text-gray-400 italic">
+                            <td colspan="4" class="px-6 py-10 text-center text-gray-400 italic">
                                 No tasks found. Add one above!
                             </td>
                         </tr>

--- a/templates/view.html.tera
+++ b/templates/view.html.tera
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>View Task - Task Tracker</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="container mx-auto px-4 py-8 max-w-2xl">
+        <header class="mb-10 text-center">
+            <h1 class="text-4xl font-extrabold text-gray-900 mb-2">Task Details</h1>
+            <p class="text-lg text-gray-600">View information about your task</p>
+        </header>
+
+        <div class="bg-white rounded-lg shadow-md p-8">
+            <div class="mb-6">
+                <label class="block mb-2 text-sm font-medium text-gray-500 uppercase tracking-wider">Task Name</label>
+                <p class="text-2xl font-bold text-gray-900">{{ task.name }}</p>
+            </div>
+
+            <div class="grid grid-cols-2 gap-6 mb-8">
+                <div>
+                    <label class="block mb-2 text-sm font-medium text-gray-500 uppercase tracking-wider">Status</label>
+                    <div class="mt-1">
+                        {% if task.status == "done" %}
+                        <span class="bg-green-100 text-green-800 text-sm font-semibold px-3 py-1 rounded-full">Done</span>
+                        {% else %}
+                        <span class="bg-blue-100 text-blue-800 text-sm font-semibold px-3 py-1 rounded-full">New</span>
+                        {% endif %}
+                    </div>
+                </div>
+                <div>
+                    <label class="block mb-2 text-sm font-medium text-gray-500 uppercase tracking-wider">Due Date</label>
+                    <p class="text-lg text-gray-900 font-medium">{{ task.date }}</p>
+                </div>
+            </div>
+
+            <div class="flex flex-col sm:flex-row gap-4 pt-6 border-t border-gray-100">
+                <a href="/task/{{ task.id }}/edit" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center justify-center">
+                    <svg class="w-4 h-4 me-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18">
+                        <path d="M12.687 14.408a3.01 3.01 0 0 1-1.533.821l-3.566.713a3 3 0 0 1-3.53-3.53l.713-3.566a3.01 3.01 0 0 1 .821-1.533L10.905 2H2.167A2.169 2.169 0 0 0 0 4.167v11.666A2.169 2.169 0 0 0 2.167 18h11.666A2.169 2.169 0 0 0 16 15.833V11.1l-3.313 3.308Zm5.53-9.065.546-.546a2.518 2.518 0 0 0 0-3.56 2.576 2.576 0 0 0-3.559 0l-.547.547 3.56 3.56Z"/>
+                        <path d="M13.243 3.2 7.359 9.081a.5.5 0 0 0-.136.256L6.51 12.9a.5.5 0 0 0 .59.59l3.566-.713a.5.5 0 0 0 .255-.136L16.8 6.759 13.243 3.2Z"/>
+                    </svg>
+                    Edit Task
+                </a>
+                <a href="/" class="py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200 text-center">
+                    Back to List
+                </a>
+                <form action="/task/{{ task.id }}/delete" method="post" class="sm:ms-auto">
+                    <button type="submit" onclick="return confirm('Are you sure you want to delete this task?')" class="text-red-600 hover:text-white border border-red-600 hover:bg-red-600 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center w-full">
+                        Delete Task
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This change adds the ability to view details of a single task and edit existing tasks. It includes:
- Backend: New database methods in `src/main.rs` for finding, updating, and deleting tasks from SQLite.
- Routes: New Rocket routes to handle viewing, editing, updating, and deleting tasks.
- Frontend: New Tera templates (`view.html.tera` and `edit.html.tera`) using Tailwind CSS and Flowbite.
- UI Updates: Added an 'Actions' column to the main task list with View, Edit, and Delete buttons.
- Testing: New integration tests in `src/main.rs` that verify the full lifecycle of viewing and editing tasks, including error handling for non-existent tasks.

---
*PR created automatically by Jules for task [834207518833276319](https://jules.google.com/task/834207518833276319) started by @lowks*