### PR TITLE
Add Autobuild Script and CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Run Autobuild Script
+      run: bash scripts/autobuild.sh

--- a/scripts/autobuild.sh
+++ b/scripts/autobuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "--- Starting Autobuild Script ---"
+
+echo "Step 1: Checking code formatting..."
+cargo fmt -- --check
+
+echo "Step 2: Running linter (clippy)..."
+cargo clippy -- -D warnings
+
+echo "Step 3: Building the project..."
+cargo build --verbose
+
+echo "Step 4: Running tests..."
+cargo test --verbose
+
+echo "--- Autobuild Script Completed Successfully! ---"

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,11 @@ async fn edit_task(db: Db, id: i64) -> Option<Template> {
 }
 
 #[post("/task/<id>", data = "<task>")]
-async fn update_task(db: Db, id: i64, task: rocket::form::Form<Task>) -> rocket::response::Redirect {
+async fn update_task(
+    db: Db,
+    id: i64,
+    task: rocket::form::Form<Task>,
+) -> rocket::response::Redirect {
     Task::update(&db, id, task.into_inner()).await;
     rocket::response::Redirect::to("/")
 }


### PR DESCRIPTION
This PR introduces automated building and testing for the project. 

Specifically:
1. **`scripts/autobuild.sh`**: A shell script that runs formatting checks (`cargo fmt`), linting (`cargo clippy`), project build, and all tests. This script is intended for both local use and CI.
2. **GitHub Actions**: Added `.github/workflows/ci.yml` which triggers on every push and pull request to the `master` branch. It utilizes the aforementioned script to ensure code quality and functionality.
3. **Code Formatting**: Applied `cargo fmt` to the existing codebase to ensure the initial CI run passes.

Fixes #3

---
*PR created automatically by Jules for task [4600694836908862350](https://jules.google.com/task/4600694836908862350) started by @lowks*