### PR TITLE
Remove 'Add Task' button and add Enter key listener to Date field

### DIFF
--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -42,9 +42,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="flex justify-end">
-                    <button type="submit" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center">Add Task</button>
-                </div>
             </form>
         </div>
 
@@ -101,5 +98,22 @@
         </div>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const dateInput = document.getElementById('date');
+            if (dateInput) {
+                dateInput.addEventListener('keydown', function(event) {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        if (typeof this.form.requestSubmit === 'function') {
+                            this.form.requestSubmit();
+                        } else {
+                            this.form.submit();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
The "Add Task" button has been removed from the task creation form on the index page. A new JavaScript event listener has been added to the Date input field (id="date") that listens for the "Enter" key and programmatically submits the form using `requestSubmit()`. This ensures that new tasks can be created quickly while still respecting form validation rules. Visual verification was performed using Playwright, and integration tests were run to ensure no regressions.

---
*PR created automatically by Jules for task [43651836330838145](https://jules.google.com/task/43651836330838145) started by @lowks*