### PR TITLE
Add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rocket SQLite Task Tracker
 
+[![Autobuild](https://github.com/lowks/test_jules_with_rust/actions/workflows/autobuild.yml/badge.svg)](https://github.com/lowks/test_jules_with_rust/actions/workflows/autobuild.yml)
+
 A modern web application built with the **Rocket** Rust framework and **SQLite** (via `rusqlite`). This application allows you to manage tasks with a name, status, and date.
 
 ## Features


### PR DESCRIPTION
Added a GitHub Actions build status badge for the `Autobuild` workflow to the `README.md` file. The badge is placed at the top of the file and links to the workflow page. Verified the change by reading the `README.md` file and running the `scripts/autobuild.sh` script to ensure all tests still pass.

---
*PR created automatically by Jules for task [5611863965355339068](https://jules.google.com/task/5611863965355339068) started by @lowks*