### PR TITLE
Add Nginx and Apache reverse proxy configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ CMD ["app"]
 
 ## Deployment
 
-To serve the application behind a reverse proxy, you can find example configuration files for Nginx and Apache in the `deployment/` directory.
+To serve the application behind a reverse proxy with HTTPS, you can find example configuration files for Nginx and Apache in the `deployment/` directory. These configurations include HTTP to HTTPS redirects and SSL/TLS settings.
 
 ### Nginx
-The `deployment/nginx.conf` file provides a standard configuration for Nginx. You should update the `server_name` and the path to the `static` directory as needed.
+The `deployment/nginx.conf` file provides a configuration for Nginx with HTTPS support. You should update the `server_name`, SSL certificate paths, and the path to the `static` directory as needed.
 
 ### Apache
-The `deployment/apache.conf` file provides a VirtualHost configuration for Apache. Ensure that the `mod_proxy` and `mod_proxy_http` modules are enabled. You should update the `ServerName` and the path to the `static` directory as needed.
+The `deployment/apache.conf` file provides a VirtualHost configuration for Apache with HTTPS support. Ensure that the `mod_ssl`, `mod_proxy`, and `mod_proxy_http` modules are enabled. You should update the `ServerName`, SSL certificate paths, and the path to the `static` directory as needed.
 
 ## License
 

--- a/deployment/apache.conf
+++ b/deployment/apache.conf
@@ -1,5 +1,14 @@
 <VirtualHost *:80>
-    ServerName example.com # Replace with your domain or IP
+    ServerName example.com
+    Redirect permanent / https://example.com/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName example.com
+
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/example.com/fullchain.pem # Replace with your cert path
+    SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem # Replace with your key path
 
     ProxyPreserveHost On
     ProxyPass / http://127.0.0.1:8000/

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,6 +1,18 @@
 server {
     listen 80;
-    server_name example.com; # Replace with your domain or IP
+    server_name example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # Replace with your cert path
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # Replace with your key path
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     location / {
         proxy_pass http://127.0.0.1:8000;
@@ -12,6 +24,6 @@ server {
 
     # Optional: Serve static files directly with Nginx
     location /static/ {
-        alias /path/to/your/app/static/; # Replace with the actual absolute path to the static directory
+        alias /path/to/your/app/static/; # Replace with actual path
     }
 }


### PR DESCRIPTION
Added example configuration files for Nginx and Apache reverse proxies to facilitate deployment. The configurations are stored in a new `deployment/` directory and documented in the `README.md`.

---
*PR created automatically by Jules for task [13509391238913885503](https://jules.google.com/task/13509391238913885503) started by @lowks*