### PR TITLE
Make Task Name and Status sortable in task list

### DIFF
--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -54,9 +54,60 @@
                 <table class="w-full text-sm text-left text-gray-500">
                     <thead class="text-xs text-gray-700 uppercase bg-gray-50">
                         <tr>
-                            <th scope="col" class="px-6 py-3">Task Name</th>
-                            <th scope="col" class="px-6 py-3 text-center">Status</th>
-                            <th scope="col" class="px-6 py-3 text-center">Date</th>
+                            <th scope="col" class="px-6 py-3">
+                                <a href="/?sort_by=name&order={{ next_order_name }}" class="flex items-center hover:text-blue-600 transition-colors">
+                                    Task Name
+                                    {% if sort_by == "name" %}
+                                    <span class="ml-1 text-blue-600">
+                                        {% if order == "asc" %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5"/>
+                                        </svg>
+                                        {% else %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+                                        </svg>
+                                        {% endif %}
+                                    </span>
+                                    {% endif %}
+                                </a>
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                <a href="/?sort_by=status&order={{ next_order_status }}" class="flex items-center justify-center hover:text-blue-600 transition-colors">
+                                    Status
+                                    {% if sort_by == "status" %}
+                                    <span class="ml-1 text-blue-600">
+                                        {% if order == "asc" %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5"/>
+                                        </svg>
+                                        {% else %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+                                        </svg>
+                                        {% endif %}
+                                    </span>
+                                    {% endif %}
+                                </a>
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                <a href="/?sort_by=date&order={{ next_order_date }}" class="flex items-center justify-center hover:text-blue-600 transition-colors">
+                                    Date
+                                    {% if sort_by == "date" %}
+                                    <span class="ml-1 text-blue-600">
+                                        {% if order == "asc" %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5"/>
+                                        </svg>
+                                        {% else %}
+                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+                                        </svg>
+                                        {% endif %}
+                                    </span>
+                                    {% endif %}
+                                </a>
+                            </th>
                             <th scope="col" class="px-6 py-3 text-right">Actions</th>
                         </tr>
                     </thead>


### PR DESCRIPTION
This change implements server-side sorting for the task list. Users can now click on "Task Name", "Status", and "Date" headers to sort the tasks in ascending or descending order. The active sort column and direction are visually indicated with chevron icons. Sorting is handled by the backend using query parameters (`sort_by` and `order`), ensuring consistent results across both the HTML UI and the JSON API.

Fixes #11

---
*PR created automatically by Jules for task [3143581316551934605](https://jules.google.com/task/3143581316551934605) started by @lowks*