### PR TITLE
Harden application for CSRF

### DIFF
--- a/templates/edit.html.tera
+++ b/templates/edit.html.tera
@@ -16,6 +16,7 @@
 
         <div class="bg-white rounded-lg shadow-md p-6">
             <form action="/task/{{ task.id }}" method="post" class="space-y-6">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <div>
                     <label for="name" class="block mb-2 text-sm font-medium text-gray-900">Task Name</label>
                     <input type="text" id="name" name="name" value="{{ task.name }}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -18,6 +18,7 @@
         <div class="bg-white rounded-lg shadow-md p-6 mb-8">
             <h2 class="text-xl font-bold text-gray-800 mb-4">Add New Task</h2>
             <form action="/task" method="post" class="space-y-4">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
                         <label for="name" class="block mb-2 text-sm font-medium text-gray-900">Task Name</label>
@@ -131,6 +132,7 @@
                                 <a href="/task/{{ task.id }}" class="font-medium text-blue-600 hover:underline">View</a>
                                 <a href="/task/{{ task.id }}/edit" class="font-medium text-green-600 hover:underline">Edit</a>
                                 <form action="/task/{{ task.id }}/delete" method="post" class="inline">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                                     <button type="submit" class="font-medium text-red-600 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
                                 </form>
                             </td>

--- a/templates/view.html.tera
+++ b/templates/view.html.tera
@@ -49,6 +49,7 @@
                     Back to List
                 </a>
                 <form action="/task/{{ task.id }}/delete" method="post" class="sm:ms-auto">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <button type="submit" onclick="return confirm('Are you sure you want to delete this task?')" class="text-red-600 hover:text-white border border-red-600 hover:bg-red-600 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center w-full">
                         Delete Task
                     </button>


### PR DESCRIPTION
I have implemented comprehensive CSRF protection for the application.

Key changes:
1. **Backend Logic**: Added a `CsrfToken` request guard in `src/main.rs` that automatically generates and manages a UUID-based token stored in a `csrf_token` cookie. The cookie is secured with `HttpOnly` and `SameSite::Lax`.
2. **Form Protection**: Updated `templates/index.html.tera`, `templates/edit.html.tera`, and `templates/view.html.tera` to include a hidden input field for the CSRF token in all POST forms.
3. **Route Hardening**: Updated all state-changing routes (`create_task_form`, `update_task`, `delete_task`, and `create_task_json`) to validate the presence and correctness of the token. The JSON endpoint requires the token in an `X-CSRF-Token` header.
4. **Testing**: Modified existing integration tests to include the CSRF token in requests. Added a new test `test_csrf_protection_enforcement` to ensure that unauthorized requests are correctly rejected.
5. **Autobuild**: Verified that all tests pass, including formatting, clippy, and UI tests using Playwright.

---
*PR created automatically by Jules for task [11740080359226296686](https://jules.google.com/task/11740080359226296686) started by @lowks*