### PR TITLE
Add admin user seed via database migration

### DIFF
--- a/migrations/V2__seed_admin_user.sql
+++ b/migrations/V2__seed_admin_user.sql
@@ -1,0 +1,1 @@
+INSERT OR IGNORE INTO users (username, password_hash) VALUES ('admin', '$2b$12$c/oBdKknFCXDD36dcflOxOzamVsTZywcX9Bjt2th6I8gMTbq9hWAG');

--- a/src/main.rs
+++ b/src/main.rs
@@ -765,22 +765,6 @@ pub fn rocket() -> _ {
                         rusqlite::Error::ExecuteReturnedResults // Dummy error
                     })?;
 
-                    // Seed admin user
-                    let count: i64 = conn.query_row(
-                        "SELECT COUNT(*) FROM users WHERE username = 'admin'",
-                        [],
-                        |row| row.get(0),
-                    )?;
-
-                    if count == 0 {
-                        let hash = bcrypt::hash("admin", bcrypt::DEFAULT_COST).map_err(|_| {
-                            rusqlite::Error::ExecuteReturnedResults // Dummy error
-                        })?;
-                        conn.execute(
-                            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
-                            ["admin", &hash],
-                        )?;
-                    }
                     Ok::<(), rusqlite::Error>(())
                 })
                 .await;


### PR DESCRIPTION
Moved the admin user seeding logic from a procedural block in src/main.rs to a dedicated SQL migration file (migrations/V2__seed_admin_user.sql). This ensures the default admin user with username 'admin' and password 'admin' is consistently created in the database during migration execution, following the user's request for a migration-based approach. All tests passed, confirming successful authentication with the new seed.

---
*PR created automatically by Jules for task [13590741788360782963](https://jules.google.com/task/13590741788360782963) started by @lowks*